### PR TITLE
unit test should be run from the root directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ cache:
 
 # Command to run tests, e.g. python setup.py test
 script:
-  - cd tests/
-  - python3 test_csv_helper.py
+  - python3 unittest


### PR DESCRIPTION
It is recommended to run the unit test from the root folder, first-run ``` python3 unittest``` on the terminal and if it works it will also work on travis